### PR TITLE
Create Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,19 @@
+FROM docker.io/library/node:24-bookworm
+
+RUN apt update \
+    && apt -y upgrade \
+    && apt -y full-upgrade \
+    && apt-get -y autoremove \
+    && apt-get -y autoclean \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g npm@11.5.1
+
+RUN mkdir /app \
+    && cd /app \
+    && wget https://github.com/stevieraykatz/HexPad/archive/refs/heads/main.zip \
+    && unzip main.zip \
+    && rm main.zip \
+    && cd HexPad-main \
+    && npm install
+
+CMD cd /app/HexPad-main && npm run dev


### PR DESCRIPTION
Here's the Containerfile I built to run HexPad locally.
- Build: `podman build -t hexpad .`
- Run: `podman run -it -p 3000:3000 --rm hexpad`

Some notes:
- It's a Containerfile instead of a Dockerfile because I prefer Podman over Docker
- It's hardcoded to fetch the most recent `main` from GitHub rather than building from the cloned repo