### PR TITLE
Pointy-Top Hexagon Layout

### DIFF
--- a/components/DesignMenuContent.tsx
+++ b/components/DesignMenuContent.tsx
@@ -7,7 +7,7 @@ import GridSizeControls from './GridSizeControls';
 import BackgroundColorSelector from './BackgroundColorSelector';
 import { UI_CONFIG } from './config';
 import type { BackgroundColor, TextureItem, HexTexture, IconItem } from './config';
-import type { NumberingMode } from './GridSizeControls';
+import type { NumberingMode, OrientationMode } from './GridSizeControls';
 
 interface DesignMenuContentProps {
   activeTab: 'paint' | 'icons' | 'borders' | 'settings';
@@ -34,12 +34,14 @@ interface DesignMenuContentProps {
   gridHeight: number;
   selectedBackgroundColor: BackgroundColor;
   numberingMode: NumberingMode;
+  orientationMode: OrientationMode;
   onWidthChange: (width: number) => void;
   onHeightChange: (height: number) => void;
   onBackgroundColorChange: (color: BackgroundColor) => void;
   // Mobile layout
   isMobile?: boolean; // Optional mobile detection for layout adjustments
   onNumberingModeChange: (mode: NumberingMode) => void;
+  onOrientationModeChange: (mode: OrientationMode) => void;
   // Region props
   regionStats?: {
     totalRegions: number;
@@ -79,10 +81,12 @@ const DesignMenuContent: React.FC<DesignMenuContentProps> = ({
   gridHeight,
   selectedBackgroundColor,
   numberingMode,
+  orientationMode,
   onWidthChange,
   onHeightChange,
   onBackgroundColorChange,
   onNumberingModeChange,
+  onOrientationModeChange,
   // Region props - REGIONING DISABLED
   regionStats: _regionStats,
   hoveredRegion: _hoveredRegion,
@@ -177,9 +181,11 @@ const DesignMenuContent: React.FC<DesignMenuContentProps> = ({
             gridWidth={gridWidth}
             gridHeight={gridHeight}
             numberingMode={numberingMode}
+            orientationMode={orientationMode}
             onWidthChange={onWidthChange}
             onHeightChange={onHeightChange}
             onNumberingModeChange={onNumberingModeChange}
+            onOrientationModeChange={onOrientationModeChange}
           />
           </div>
           <div className={isMobile ? 'mobile-section' : ''}>

--- a/components/GridSizeControls.tsx
+++ b/components/GridSizeControls.tsx
@@ -2,23 +2,28 @@ import React from 'react';
 import { GRID_CONFIG, UI_CONFIG } from './config';
 
 export type NumberingMode = 'off' | 'edge' | 'in-hex';
+export type OrientationMode = 'flat-top' | 'pointy-top';
 
 interface GridSizeControlsProps {
   gridWidth: number;
   gridHeight: number;
   numberingMode: NumberingMode;
+  orientationMode: OrientationMode;
   onWidthChange: (width: number) => void;
   onHeightChange: (height: number) => void;
   onNumberingModeChange: (mode: NumberingMode) => void;
+  onOrientationModeChange: (mode: OrientationMode) => void;
 }
 
 const GridSizeControls: React.FC<GridSizeControlsProps> = ({
   gridWidth,
   gridHeight,
   numberingMode,
+  orientationMode,
   onWidthChange,
   onHeightChange,
-  onNumberingModeChange
+  onNumberingModeChange,
+  onOrientationModeChange
 }) => {
   const sliderStyle = {
     width: UI_CONFIG.APP_LAYOUT.FULL_WIDTH_PERCENTAGE,
@@ -90,6 +95,28 @@ const GridSizeControls: React.FC<GridSizeControlsProps> = ({
           <option value="off">Off</option>
           <option value="edge">Edge Numbering</option>
           <option value="in-hex">In-Hex Numbering</option>
+        </select>
+        <div style={{
+          fontSize: UI_CONFIG.FONT_SIZE.SMALL,
+          color: UI_CONFIG.COLORS.TEXT_MUTED,
+          marginTop: UI_CONFIG.SPACING.SMALL,
+          lineHeight: '1.4'
+        }}>
+        </div>
+      </div>
+
+      
+      <div>
+        <label style={labelStyle}>
+          Hexagon Orientation
+        </label>
+        <select
+          value={orientationMode}
+          onChange={(e) => onOrientationModeChange(e.target.value as OrientationMode)}
+          style={selectStyle}
+        >
+          <option value="flat-top">Flat Top</option>
+          <option value="pointy-top">Pointy Top</option>
         </select>
         <div style={{
           fontSize: UI_CONFIG.FONT_SIZE.SMALL,

--- a/components/HexGridApp.tsx
+++ b/components/HexGridApp.tsx
@@ -3,7 +3,7 @@ import HexGrid, { HexGridRef } from './HexGrid';
 import { UI_CONFIG, PAINT_OPTIONS, BACKGROUND_COLORS, ICON_OPTIONS, getManilaColor } from './config';
 import type { BackgroundColor, IconItem, HexTexture } from './config';
 import { loadTerrainManifest, getTerrainInfo } from './config/assetLoader';
-import type { NumberingMode } from './GridSizeControls';
+import type { NumberingMode, OrientationMode } from './GridSizeControls';
 
 import TopCornerLinks from './TopCornerLinks';
 import MenuToggleButton from './MenuToggleButton';
@@ -48,6 +48,7 @@ const HexGridApp: React.FC = () => {
   const [isExporting, setIsExporting] = useState<boolean>(false);
   const [selectedBackgroundColor, setSelectedBackgroundColor] = useState<BackgroundColor>(BACKGROUND_COLORS[0]);
   const [numberingMode, setNumberingMode] = useState<NumberingMode>('off');
+  const [orientationMode, setOrientationMode] = useState<OrientationMode>('flat-top');
   const hexGridRef = useRef<HexGridRef>(null);
   const appContainerRef = useRef<HTMLDivElement>(null);
   
@@ -150,6 +151,7 @@ const HexGridApp: React.FC = () => {
     selectedIconColor,
     selectedBorderColor,
     selectedBackgroundColor: selectedBackgroundShaderColor,
+    orientationMode,
     activeTab,
     onPaintStart: handlePaintStart
   });
@@ -517,11 +519,13 @@ const HexGridApp: React.FC = () => {
           gridHeight={gridHeight}
           selectedBackgroundColor={selectedBackgroundColor}
           numberingMode={numberingMode}
+          orientationMode={orientationMode}
           selectedTexture={selectedTexture}
           onWidthChange={setGridWidth}
           onHeightChange={setGridHeight}
           onBackgroundColorChange={setSelectedBackgroundColor}
           onNumberingModeChange={setNumberingMode}
+          onOrientationModeChange={setOrientationMode}
           onTextureSelect={handleTextureSelect}
           selectedIcon={selectedIcon}
           selectedIconColor={selectedIconColor}
@@ -582,6 +586,7 @@ const HexGridApp: React.FC = () => {
           gridWidth={gridWidth} 
           gridHeight={gridHeight}
           numberingMode={numberingMode}
+          orientationMode={orientationMode}
           onHexClick={eyeDropperMode ? handleEyeDropperClick : (
             (backgroundPaintingMode && selectedIcon?.name !== 'eraser') || 
             (!selectedTexture && selectedIcon?.name !== 'eraser' && activeTab === 'paint') 

--- a/components/config/gridConfig.ts
+++ b/components/config/gridConfig.ts
@@ -11,6 +11,8 @@
  * - Canvas margins: CANVAS_MARGIN_FACTOR controls how much border space around the grid (0.95 = 5% margin)
  */
 
+import { OrientationMode } from "../GridSizeControls";
+
 export interface GridConfig {
   // Default grid dimensions
   readonly DEFAULT_WIDTH: number;
@@ -24,6 +26,7 @@ export interface GridConfig {
   readonly HEX_HORIZONTAL_SPACING_RATIO: number; // Distance between hex centers horizontally (as ratio of hex width)
   readonly HEX_ROW_VERTICAL_OFFSET: number; // Vertical offset for alternating columns (as ratio of hex height)
   readonly HEX_VISUAL_SIZE_RATIO: number; // Visual size of hexagons relative to their radius (0.9 = 90% size, creates spacing)
+  readonly POINTY_TOP_HEX_HORIZONTAL_SPACING_RATIO: number; // Distance between hex centers horizontally (as ratio of hex width) for vertical hexagon layout
   
   // Canvas sizing
   readonly CANVAS_MARGIN_FACTOR: number; // Leave 5% margin around the grid
@@ -85,6 +88,7 @@ export const GRID_CONFIG: GridConfig = {
   
   // Hex geometry constants
   HEX_HORIZONTAL_SPACING_RATIO: 0.75, // Distance between hex centers horizontally (as ratio of hex width)
+  POINTY_TOP_HEX_HORIZONTAL_SPACING_RATIO: 0.5, // Distance between hex centers horizontally (as ratio of hex width) for pointy-top hexagon layout
   HEX_ROW_VERTICAL_OFFSET: 0.5, // Vertical offset for alternating columns (as ratio of hex height)
   HEX_VISUAL_SIZE_RATIO: 0.95, // Visual size of hexagons relative to their radius (0.95 = 95% size, higher value creates less spacing)
   
@@ -146,30 +150,34 @@ export interface HexGeometry {
   readonly SQRT_3: number; // Square root of 3 for hex height calculations
   
   // Calculate hex width from radius
-  getHexWidth: (radius: number) => number;
+  getHexWidth: (radius: number, orientationMode: OrientationMode) => number;
   
   // Calculate hex height from radius  
-  getHexHeight: (radius: number) => number;
+  getHexHeight: (radius: number, orientationMode: OrientationMode) => number;
   
   // Calculate horizontal spacing between hex centers
-  getHorizontalSpacing: (radius: number) => number;
+  getHorizontalSpacing: (radius: number, orientationMode: OrientationMode) => number;
   
   // Calculate vertical spacing between hex centers
-  getVerticalSpacing: (radius: number) => number;
+  getVerticalSpacing: (radius: number, orientationMode: OrientationMode) => number;
 }
 
 export const HEX_GEOMETRY: HexGeometry = {
   SQRT_3: Math.sqrt(3), // Square root of 3 for hex height calculations
   
   // Calculate hex width from radius
-  getHexWidth: (radius: number): number => radius * 2,
+  getHexWidth: (radius: number, orientationMode: OrientationMode): number => orientationMode === 'pointy-top' ? (radius * 1.75) : (radius * 2),
   
-  // Calculate hex height from radius  
-  getHexHeight: (radius: number): number => radius * HEX_GEOMETRY.SQRT_3,
+  // Calculate hex height from radius
+  getHexHeight: (radius: number, orientationMode: OrientationMode): number => orientationMode === 'pointy-top' ? (radius * 2.5) : (radius * HEX_GEOMETRY.SQRT_3),
   
   // Calculate horizontal spacing between hex centers
-  getHorizontalSpacing: (radius: number): number => HEX_GEOMETRY.getHexWidth(radius) * GRID_CONFIG.HEX_HORIZONTAL_SPACING_RATIO,
+  getHorizontalSpacing: (radius: number, orientationMode: OrientationMode): number => orientationMode === 'pointy-top' ? 
+    (HEX_GEOMETRY.getHexWidth(radius, orientationMode) * GRID_CONFIG.POINTY_TOP_HEX_HORIZONTAL_SPACING_RATIO) :
+    (HEX_GEOMETRY.getHexWidth(radius, orientationMode) * GRID_CONFIG.HEX_HORIZONTAL_SPACING_RATIO),
   
   // Calculate vertical spacing between hex centers
-  getVerticalSpacing: (radius: number): number => HEX_GEOMETRY.getHexHeight(radius),
+  getVerticalSpacing: (radius: number, orientationMode: OrientationMode): number => orientationMode === 'pointy-top' ?
+    (HEX_GEOMETRY.getHexHeight(radius, orientationMode) * 1.2) :
+    (HEX_GEOMETRY.getHexHeight(radius, orientationMode)),
 }; 

--- a/hooks/useGridState.ts
+++ b/hooks/useGridState.ts
@@ -6,6 +6,7 @@ import { useRegionState } from './useRegionState';
 import { useRegionBorders } from './useRegionBorders';
 import type { RegionMap } from '../utils/regionUtils';
 import { getRandomTerrainVariant, getTerrainInfo } from '../components/config/assetLoader';
+import { OrientationMode } from '@/components/GridSizeControls';
 
 // Type definitions for hex colors and textures
 type HexColor = string;
@@ -39,6 +40,7 @@ interface UseGridStateProps {
   selectedBackgroundColor: string;
   activeTab: 'paint' | 'icons' | 'borders' | 'settings';
   onPaintStart?: () => void; // Optional callback for when painting starts
+  orientationMode: OrientationMode;
   enableRegions?: boolean; // Enable region tracking (default: true)
   enableRegionBorders?: boolean; // Enable region border functionality (default: true)
 }
@@ -111,6 +113,7 @@ export function useGridState({
   selectedBackgroundColor,
   activeTab,
   onPaintStart,
+  orientationMode,
   enableRegions = true,
   enableRegionBorders = true
 }: UseGridStateProps): UseGridStateReturn {
@@ -149,6 +152,7 @@ export function useGridState({
     hexColors,
     gridWidth,
     gridHeight,
+    orientationMode,
     enabled: enableRegionBorders && enableRegions
   });
   

--- a/hooks/usePinchZoomPan.ts
+++ b/hooks/usePinchZoomPan.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useEffect } from 'react';
 import { calculateZoomLimits, constrainPanOffset } from '../utils/zoomPanUtils';
 import { GRID_CONFIG } from '../components/config/gridConfig';
 import type { CanvasSize, PanOffset } from '../utils/hexagonUtils';
+import { OrientationMode } from '@/components/GridSizeControls';
 
 interface UsePinchZoomPanOptions {
   canvasSize: CanvasSize;
@@ -15,6 +16,7 @@ interface UsePinchZoomPanOptions {
   onGestureStart?: () => void;
   onGestureEnd?: () => void;
   disabled?: boolean;
+  orientationMode: OrientationMode;
 }
 
 interface TouchState {
@@ -36,7 +38,8 @@ export const usePinchZoomPan = ({
   onPanChange,
   onGestureStart,
   onGestureEnd,
-  disabled = false
+  disabled = false,
+  orientationMode
 }: UsePinchZoomPanOptions) => {
   
   const containerRef = useRef<HTMLElement | null>(null);
@@ -96,7 +99,8 @@ export const usePinchZoomPan = ({
       projectedRadius,
       gridWidth,
       gridHeight,
-      canvasSize
+      canvasSize,
+      orientationMode
     );
     
     onZoomChange(newZoom, constrainedOffset);
@@ -188,7 +192,8 @@ export const usePinchZoomPan = ({
           projectedRadius,
           gridWidth,
           gridHeight,
-          canvasSize
+          canvasSize,
+          orientationMode
         );
         
         onZoomChange(newZoom, constrainedOffset);
@@ -207,7 +212,8 @@ export const usePinchZoomPan = ({
           currentHexRadius,
           gridWidth,
           gridHeight,
-          canvasSize
+          canvasSize,
+          orientationMode
         );
         
         onPanChange(constrainedOffset);

--- a/utils/zoomPanUtils.ts
+++ b/utils/zoomPanUtils.ts
@@ -4,6 +4,7 @@
  * Helper functions for zoom level calculations, pan limits, and zoom-to-cursor behavior.
  */
 
+import { OrientationMode } from '@/components/GridSizeControls';
 import { GRID_CONFIG, HEX_GEOMETRY } from '../components/config';
 import type { CanvasSize, PanOffset } from './hexagonUtils';
 
@@ -42,15 +43,16 @@ export const calculatePanLimits = (
   hexRadius: number,
   gridWidth: number,
   gridHeight: number,
-  canvasSize: CanvasSize
+  canvasSize: CanvasSize,
+  orientationMode: OrientationMode
 ): PanLimits => {
-  const hexWidth = HEX_GEOMETRY.getHexWidth(hexRadius);
-  const hexHeight = HEX_GEOMETRY.getHexHeight(hexRadius);
-  const horizontalSpacing = HEX_GEOMETRY.getHorizontalSpacing(hexRadius);
-  const verticalSpacing = HEX_GEOMETRY.getVerticalSpacing(hexRadius);
+  const hexWidth = HEX_GEOMETRY.getHexWidth(hexRadius, orientationMode);
+  const hexHeight = HEX_GEOMETRY.getHexHeight(hexRadius, orientationMode);
+  const horizontalSpacing = HEX_GEOMETRY.getHorizontalSpacing(hexRadius, orientationMode);
+  const verticalSpacing = HEX_GEOMETRY.getVerticalSpacing(hexRadius, orientationMode);
   
   const totalGridWidth = (gridWidth - 1) * horizontalSpacing + hexWidth;
-  const totalGridHeight = gridHeight * verticalSpacing;
+  const totalGridHeight = gridHeight * verticalSpacing - hexHeight;
   
   // Calculate how much the grid exceeds the container size
   const excessWidth = Math.max(0, totalGridWidth - canvasSize.width);
@@ -73,9 +75,10 @@ export const constrainPanOffset = (
   hexRadius: number,
   gridWidth: number,
   gridHeight: number,
-  canvasSize: CanvasSize
+  canvasSize: CanvasSize,
+  orientationMode: OrientationMode
 ): PanOffset => {
-  const { minPanX, maxPanX, minPanY, maxPanY } = calculatePanLimits(hexRadius, gridWidth, gridHeight, canvasSize);
+  const { minPanX, maxPanX, minPanY, maxPanY } = calculatePanLimits(hexRadius, gridWidth, gridHeight, canvasSize, orientationMode);
   return {
     x: Math.max(minPanX, Math.min(maxPanX, offset.x)),
     y: Math.max(minPanY, Math.min(maxPanY, offset.y))
@@ -94,7 +97,8 @@ export const calculateZoomToPoint = (
   currentPanOffset: PanOffset,
   currentHexRadius: number,
   gridWidth: number,
-  gridHeight: number
+  gridHeight: number,
+  orientationMode: OrientationMode
 ): { newZoom: number; newPanOffset: PanOffset } => {
   const { minZoom, maxZoom } = calculateZoomLimits(gridWidth);
   
@@ -127,7 +131,8 @@ export const calculateZoomToPoint = (
     projectedRadius, 
     gridWidth, 
     gridHeight, 
-    canvasSize
+    canvasSize,
+    orientationMode
   );
   
   return { newZoom: clampedZoom, newPanOffset: constrainedOffset };


### PR DESCRIPTION
Adds a drop down option to switch layouts between Flat-Top (current) and Pointy-Top (new) hexagon orientations.

Making assumptions on angles and other factors based on this explanation.
https://www.redblobgames.com/grids/hexagons/

REMAINING ISSUES:
* Update canvas rendering when changing `orientationMode` option. Currently does not update until zoom and menu tab is changed.

* Store the `orientationMode` value in the save and load functionality to maintain between user sessions.

* Adjust zoom to handle the extra height of `pointy-top` orientation at low width settings,
<img width="1400" height="945" alt="image" src="https://github.com/user-attachments/assets/0153006a-4150-401f-856c-ea6895d72cab" />
<img width="1368" height="957" alt="image" src="https://github.com/user-attachments/assets/c925388e-cc43-430f-8cb0-9dbc3cc8adde" />

* Border display for `left` and `right` needs to use 90/270 angle when in `pointy-top` orientation.
<img width="1416" height="2595" alt="hex-grid-8x5-2025-09-19T05-03-21" src="https://github.com/user-attachments/assets/ded82b93-f372-4a59-96b9-c36928c7dfc3" />

